### PR TITLE
Fix overriding handlers issue.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -235,6 +235,7 @@ class Autocomplete extends Component {
     } = this.props;
 
     const childrenProps = {
+      ...rest,
       editorState,
       onChange,
       onFocus: this.onFocus,
@@ -244,8 +245,7 @@ class Autocomplete extends Component {
       onEscape: this.onEscape,
       onTab: this.onTab,
       keyBindingFn: this.keyBindingFn,
-      handleKeyCommand: this.handleKeyCommand,
-      ...rest
+      handleKeyCommand: this.handleKeyCommand      
     };
 
     return React.Children.map(


### PR DESCRIPTION
When a handler is passed as a prop to the Autocomplete module, the same handler is passed to it's child.
So, when the child's handler handles an event, it propagates the event to the handler of the props. Thus, **the handler of the Autocomplete module was overwritten**. 
To avoid that issue, we should pass to the child the handler of the Autocomplete module, which in turns it will call the handler of the props.